### PR TITLE
fix: remove type parameters

### DIFF
--- a/packages/grpc/package.json
+++ b/packages/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@join-com/grpc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "gRPC library",
   "license": "MIT",
   "scripts": {

--- a/packages/grpc/src/Service.ts
+++ b/packages/grpc/src/Service.ts
@@ -90,15 +90,13 @@ export class Service<
   // Although it would allow us to remove a lot of ESlint "disable" directives in this file, we can't make
   // `ServiceImplementationType` to extend grpc.UntypedServiceImplementation, because of the "indexed properties" it
   // introduces. The "indexed properties" would make impossible to instantiate
-  ServiceImplementationType = grpc.UntypedServiceImplementation,
-  ServiceDefinitionType extends grpc.ServiceDefinition<ServiceImplementationType> = grpc.ServiceDefinition<ServiceImplementationType>,
-  CustomImplementationType extends JoinServiceImplementation<ServiceImplementationType> = JoinServiceImplementation<ServiceImplementationType>
-> implements IServiceMapping<ServiceImplementationType, ServiceDefinitionType> {
+  ServiceImplementationType = grpc.UntypedServiceImplementation
+> implements IServiceMapping<ServiceImplementationType> {
   public readonly implementation: ServiceImplementationType
 
   constructor(
-    public readonly definition: ServiceDefinitionType,
-    implementation: CustomImplementationType,
+    public readonly definition: grpc.ServiceDefinition<ServiceImplementationType>,
+    implementation: JoinServiceImplementation<ServiceImplementationType>,
     protected readonly logger?: INoDebugLogger,
     private readonly trace?: IServiceTrace,
   ) {
@@ -106,7 +104,7 @@ export class Service<
   }
 
   private adaptImplementation(
-    promisifiedImplementation: CustomImplementationType,
+    promisifiedImplementation: JoinServiceImplementation<ServiceImplementationType>,
   ): ServiceImplementationType {
     return Object.entries(promisifiedImplementation).reduce(
       (acc, [name, handler]) => {

--- a/packages/grpc/src/interfaces/IServiceMapping.ts
+++ b/packages/grpc/src/interfaces/IServiceMapping.ts
@@ -1,9 +1,8 @@
 import * as grpc from '@grpc/grpc-js'
 
 export interface IServiceMapping<
-  ServiceImplementationType = grpc.UntypedServiceImplementation,
-  ServiceDefinitionType extends grpc.ServiceDefinition<ServiceImplementationType> = grpc.ServiceDefinition<ServiceImplementationType>
+  ServiceImplementationType = grpc.UntypedServiceImplementation
 > {
-  readonly definition: ServiceDefinitionType
+  readonly definition: grpc.ServiceDefinition<ServiceImplementationType>
   readonly implementation: ServiceImplementationType
 }


### PR DESCRIPTION
decrease types flexibility, as it was not adding any value, and the
typescript's type inference mechanism is sometimes buggy when it has to
deal with "big" types.