### PR TITLE
[JOIN-13991] Adjust grpc calls to support opentelemetry auto instrumentation

### DIFF
--- a/packages/grpc/package.json
+++ b/packages/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@join-com/grpc",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "gRPC library",
   "license": "MIT",
   "scripts": {

--- a/packages/grpc/package.json
+++ b/packages/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@join-com/grpc",
-  "version": "2.1.1",
+  "version": "2.2.1-alpha",
   "description": "gRPC library",
   "license": "MIT",
   "scripts": {

--- a/packages/grpc/src/Client.ts
+++ b/packages/grpc/src/Client.ts
@@ -123,7 +123,7 @@ export abstract class Client<
         method,
         argument,
         this.prepareMetadata(metadata),
-        options || {},
+        options ?? {},
         this.createCallback(resolve, reject, methodPath, chronometer, argument),
       ) as grpc.ClientUnaryCall
     })


### PR DESCRIPTION
[JOIN-13991]

this.client instance created with service definition already includes the set of specific grpc service methods and can be called like this.client.Check(). Check method is decorated makeUnaryRequest method which already passes path, serialize, deserialize parameters.

For reference how methods are built
https://github.com/grpc/grpc-node/blob/aeb42733d861883b82323e2dc6d1aba0e3a12aa0/packages/grpc-js/src/make-client.ts#L158
https://github.com/grpc/grpc-node/blob/aeb42733d861883b82323e2dc6d1aba0e3a12aa0/packages/grpc-js/src/make-client.ts#L178

[JOIN-13991]: https://joinsolutionsag.atlassian.net/browse/JOIN-13991