### PR TITLE
feat(errors): JOIN-15460 Deescalate validation errors

### DIFF
--- a/packages/grpc/package.json
+++ b/packages/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@join-com/grpc",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "gRPC library",
   "license": "MIT",
   "scripts": {

--- a/packages/grpc/src/Client.ts
+++ b/packages/grpc/src/Client.ts
@@ -153,6 +153,8 @@ export abstract class Client<
         if (error.code === grpc.status.NOT_FOUND) {
           // We don't mark "not found" as an error in our logs
           this.logger?.info(`GRPC Client ${methodPath}`, logData)
+        } else if (patchedError.code === 'validation') {
+          this.logger?.warn(`GRPC Client ${methodPath}`, logData)
         } else {
           this.logger?.error(`GRPC Client ${methodPath}`, logData)
         }

--- a/packages/grpc/src/Service.ts
+++ b/packages/grpc/src/Service.ts
@@ -331,11 +331,18 @@ export class Service<
       latency: chronometer?.getEllapsedTime(),
     }
 
-    type EE = Error & { code?: string }
-    if (isError && (result as EE).code !== 'notFound') {
-      this.logger.error(`GRPC Service ${methodDefinition.path}`, logData)
-    } else {
+    if (!isError) {
       this.logger.info(`GRPC Service ${methodDefinition.path}`, logData)
+      return
+    }
+
+    const error = result as Error & { code?: string }
+    if (error.code === 'notFound') {
+      this.logger.info(`GRPC Service ${methodDefinition.path}`, logData)
+    } else if (error.code === 'validation') {
+      this.logger.warn(`GRPC Service ${methodDefinition.path}`, logData)
+    } else {
+      this.logger.error(`GRPC Service ${methodDefinition.path}`, logData)
     }
   }
 }


### PR DESCRIPTION
This will reduce the noise coming from the alert policy triggered by the # of errors in logs. 
In general validation error should not be considered as an error bc it's a correct behaivor of the service. It only indicates that there is a validation missing on the client side. 

The whole error handling in grpc will be reviewed and redone in the next major release

[JOIN-15460]

[JOIN-15460]: https://joinsolutionsag.atlassian.net/browse/JOIN-15460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ