### PR TITLE
feat: JOIN-35045 allow to configure service name vie env var

### DIFF
--- a/packages/grpc/src/Service.ts
+++ b/packages/grpc/src/Service.ts
@@ -176,11 +176,14 @@ export class Service<
         callback(null, result)
       }
 
-      this.failIfDisabled(methodDefinition.path, call.metadata)
+      const processDisabled = () => {
+        this.failIfDisabled(methodDefinition.path, call.metadata)
+      }
 
       // Promise.resolve guarantees that the handler is always executed asynchronously.
       // Ex. handler can be defined as a synchronous function returning promise and throwing error inside.
       Promise.resolve()
+        .then(processDisabled)
         .then(() => promiseHandler(call))
         .then(processResult)
         .catch(processError)
@@ -288,7 +291,7 @@ export class Service<
   }
 
   private failIfDisabled(path: string, metadata: grpc.Metadata) {
-    const serviceName = this.getServiceName(path)
+    const serviceName = process.env['GRPC_SERVICE_NAME'] || this.getServiceName(path)
     const disableServices = this.getDisableServices(metadata)
     if (serviceName && disableServices?.includes(serviceName)) {
       throw new Error(


### PR DESCRIPTION
https://github.com/search?q=org%3Ajoin-com+%2F%5Epackage%2F+path%3A*.proto+-path%3Ahealth.proto+NOT+%22package+google%22+NOT+repo%3Ajoin-com%2Fprotobuf.js+NOT+repo%3Ajoin-com%2Fprotobuf&type=code

Because of naming inconsistencies we need a way to override the name

env var seams to be the easiest option
